### PR TITLE
COV-2658: Add some new postgres metrics for primary key overflows

### DIFF
--- a/.profile.d/support/configure_dd_for_postgres.rb
+++ b/.profile.d/support/configure_dd_for_postgres.rb
@@ -23,6 +23,7 @@ ENV.keys.grep(/_URL$/).each do |key|
       'ssl' => true,
       'dbname' => uri.path.split(/^[?\/]/).detect { |p| p && !p.empty? },
       'tags' => tags,
+      # Example https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example
       'custom_queries' => [{
         'query' => 'SELECT id FROM public.references ORDER BY id DESC LIMIT 1',
         'columns' => [
@@ -37,18 +38,6 @@ ENV.keys.grep(/_URL$/).each do |key|
         ],
         'collection_interval' => 14_400 # 4 hours
       }]
-
-    # custom_queries:
-    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
-    #     columns:
-    #     - name: foo
-    #       type: tag
-    #     - name: event.total
-    #       type: gauge
-    #     tags:
-    #     - test:postgresql
-    #     metric_prefix: postgresql
-
     }
   end
 end

--- a/.profile.d/support/configure_dd_for_postgres.rb
+++ b/.profile.d/support/configure_dd_for_postgres.rb
@@ -23,6 +23,32 @@ ENV.keys.grep(/_URL$/).each do |key|
       'ssl' => true,
       'dbname' => uri.path.split(/^[?\/]/).detect { |p| p && !p.empty? },
       'tags' => tags,
+      'custom_queries' => [{
+        'query' => 'SELECT id FROM public.references ORDER BY id DESC LIMIT 1',
+        'columns' => [
+          { 'name' => 'references_latest_id', 'type' => 'gauge' }
+        ],
+        'collection_interval' => 14_400 # 4 hours
+      },
+      {
+        'query' => 'SELECT id FROM public.study_votes ORDER BY id DESC LIMIT 1',
+        'columns' => [
+          { 'name' => 'study_votes_latest_id', 'type' => 'gauge' }
+        ],
+        'collection_interval' => 14_400 # 4 hours
+      }]
+
+    # custom_queries:
+    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
+    #     columns:
+    #     - name: foo
+    #       type: tag
+    #     - name: event.total
+    #       type: gauge
+    #     tags:
+    #     - test:postgresql
+    #     metric_prefix: postgresql
+
     }
   end
 end


### PR DESCRIPTION
Adding some config for custom metrics to the postgres integration with datadog.