### PR TITLE
FALCON-182: Use documented PostgreSQL paths

### DIFF
--- a/.profile.d/support/configure_dd_for_postgres.rb
+++ b/.profile.d/support/configure_dd_for_postgres.rb
@@ -70,8 +70,8 @@ ENV.keys.grep(/_URL$/).each do |key|
 end
 
 if instances.any?
-  FileUtils.mkdir_p('/app/datadog/conf.d/')
-  File.open('datadog/conf.d/postgres.yaml', 'w') do |f|
+  FileUtils.mkdir_p('/app/datadog/conf.d/postgres.d')
+  File.open('datadog/conf.d/postgres.d/conf.yaml', 'w') do |f|
     f.write YAML.dump({
       'init_config' => nil,
       'instances' => instances


### PR DESCRIPTION
This PR updates the location of custom integration YAML files to match the documentation:
https://docs.datadoghq.com/agent/basic_agent_usage/heroku/#enabling-other-integrations

If this works, we'll probably want to update the other services to match. Though the fact Elasticsearch is working right now makes me uncertain as to how much this matters.